### PR TITLE
 ✨ Add some searching and filtering to the admin

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.humanize",
 ]
 
 # Third-party apps

--- a/works/admin.py
+++ b/works/admin.py
@@ -27,7 +27,7 @@ class WorkAdmin(WordCountMixin, admin.ModelAdmin):
     list_display = ("title", "author", "complete", "status", "words")
     list_filter = ("status", "complete")
     search_fields = ("author__username", "title")
-    readonly_fields = ("url", "platform_id", "author", "title", "summary", "complete", "words", "date_published", "date_updated", "metadata")
+    readonly_fields = ("url", "platform_id", "author", "title", "summary", "complete", "word_count", "date_published", "date_updated", "metadata")
 
 
 admin.site.register(Author, AuthorAdmin)

--- a/works/admin.py
+++ b/works/admin.py
@@ -1,14 +1,33 @@
 from django.contrib import admin
+from django.contrib.humanize.templatetags.humanize import intcomma
 
 from works.models import Author, Work
 
 
+class WordCountMixin:
+    def words(self, obj):
+        return intcomma(obj.word_count)
+
+
+class WorksInline(WordCountMixin, admin.TabularInline):
+    model = Work
+    fields = ("title", "complete", "words")
+    readonly_fields = ("title", "complete", "words")
+
+
 class AuthorAdmin(admin.ModelAdmin):
-    pass
+    list_display = ("username", "url")
+    search_fields = ("username",)
+    readonly_fields = ("username", "url")
+    inlines = [WorksInline]
 
 
-class WorkAdmin(admin.ModelAdmin):
-    pass
+class WorkAdmin(WordCountMixin, admin.ModelAdmin):
+    date_hierarchy = "date_published"
+    list_display = ("title", "author", "complete", "status", "words")
+    list_filter = ("status", "complete")
+    search_fields = ("author__username", "title")
+    readonly_fields = ("url", "platform_id", "author", "title", "summary", "complete", "words", "date_published", "date_updated", "metadata")
 
 
 admin.site.register(Author, AuthorAdmin)


### PR DESCRIPTION
# Works Admin 

- Nice filterable view by year published 
- title, author, completed, read status, and humanized word count in list view 
- searchable by author username and title 
- Filterable by read status and completion status 

![Screen Shot 2022-10-24 at 3 43 32 PM](https://user-images.githubusercontent.com/2286304/197643898-b1ec7603-2caa-4a83-b08f-13ada53e61f8.png)

## Detail view 

- All fields except read status are readonly 
- Link to Author 

![Screen Shot 2022-10-24 at 3 47 30 PM](https://user-images.githubusercontent.com/2286304/197644172-33e4c967-4db3-4ffb-b561-6bc2f5a456dc.png)

# Authors Admin 

- Author username and url 
- Searchable by username 

![Screen Shot 2022-10-24 at 3 43 49 PM](https://user-images.githubusercontent.com/2286304/197644216-e20da2ce-0a68-47f5-9452-a58a513826f4.png)

## Detail view 

- All fields readonly 
- Works fieldset at the bottom with same columns as the Works table 

![Screen Shot 2022-10-24 at 3 44 04 PM](https://user-images.githubusercontent.com/2286304/197644260-746c9183-1230-472e-b681-9cf3fff20cb5.png)

